### PR TITLE
use lz4 4.1.5 with ARM support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/maxlaverse/synocrypto
 go 1.15
 
 require (
-	github.com/pierrec/lz4/v4 v4.1.5-0.20210406114008-786886575631
+	github.com/pierrec/lz4/v4 v4.1.5
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pierrec/lz4/v4 v4.1.5-0.20210406114008-786886575631 h1:6Wie378FsL8UEUBgNGQHODVSlgS1mPH0vYWke8ZoH+U=
-github.com/pierrec/lz4/v4 v4.1.5-0.20210406114008-786886575631/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.5 h1:dkfLMLT4VzmyokeD8L/VFihTqhMfXMAXw3H1YtKwEuM=
+github.com/pierrec/lz4/v4 v4.1.5/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
The 4.1.5 includes both patches for Block Dependency support:
* [implement linked block decompression](https://github.com/pierrec/lz4/pull/121)
* [lz4block: Use Go encoder with a dictionary on arm](https://github.com/pierrec/lz4/pull/122)